### PR TITLE
chore(http-client): reduce the quality factor of application/json

### DIFF
--- a/lib/api-client/http-client.js
+++ b/lib/api-client/http-client.js
@@ -53,7 +53,7 @@ HttpClient.prototype.post = function(path, options) {
   var url = this.config.baseUrl + (path ? '/'+ path : '');
   var req = request
     .post(url)
-    .set('Accept', 'application/hal+json, application/json')
+    .set('Accept', 'application/hal+json, application/json; q=0.5')
     .send(options.data || {});
 
   req.end(function(err, response) {
@@ -88,7 +88,7 @@ HttpClient.prototype.load = function(url, options) {
 
   var req = request
     .get(url)
-    .set('Accept', 'application/hal+json, application/json')
+    .set('Accept', 'application/hal+json, application/json; q=0.5')
     .query(options.data || {});
 
   req.end(function(err, response) {
@@ -114,7 +114,7 @@ HttpClient.prototype.put = function(path, options) {
 
   var req = request
     .put(url)
-    .set('Accept', 'application/hal+json, application/json')
+    .set('Accept', 'application/hal+json, application/json; q=0.5')
     .send(options.data || {});
 
   req.end(function(err, response) {
@@ -141,7 +141,7 @@ HttpClient.prototype.del = function(path, options) {
 
   var req = request
     .del(url)
-    .set('Accept', 'application/hal+json, application/json')
+    .set('Accept', 'application/hal+json, application/json; q=0.5')
     .send(options.data || {});
 
   req.end(function(err, response) {


### PR DESCRIPTION
In RFC2616 section 14.1 an accept parameter q is specified which
'indicate the relative degree of preference' of a media type in
the accept header. Since Wildfly doesn't seem to respect the ordering
we can workaround the wrong response media type selection by reduce
the quality factor of the less favored media type 'application/json'.
This should not have a negative effect on any other application
server because it is part of the HTTP spec.

related to #CAM-2718
