### PR TITLE
fix (docs): Replace string with empty braces

### DIFF
--- a/doc/embedded-forms/complex-data.md
+++ b/doc/embedded-forms/complex-data.md
@@ -36,7 +36,7 @@ In case the variable does not yet exist (for instance in a Start Form), you have
     camForm.variableManager.createVariable({
       name: 'invoiceData',
       type: 'Object',
-      value: '{}',
+      value: {},
       serializationConfig: {
         dataFormatId: 'application/json; implementation=tree',
         rootType: 'org.my.project.dto.InvoiceData'


### PR DESCRIPTION
Form requires an empty object (empty braces), not a string containing
empty braces.
