### PR TITLE
fix(http-client) Added check for empty js object

### DIFF
--- a/lib/api-client/http-client.js
+++ b/lib/api-client/http-client.js
@@ -44,7 +44,7 @@ function end(self, done) {
     // and.. it does not parse the response if it does not have
     // the "application/json" type.
     if (response.type === 'application/hal+json') {
-      if (!response.body) {
+      if (!response.body || Object.keys(response.body).length === 0) {
         response.body = JSON.parse(response.text);
       }
 


### PR DESCRIPTION
When having a 'application/hal+json' response, superagent seems to return an empty javascript object but not null.
So I added a check using the following function: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/keys#Browser_compatibility