### PR TITLE
Feature: CAM-4069 I can set custom request headers using the HTTP-Client in JS SDK

### DIFF
--- a/lib/api-client/http-client-mock.js
+++ b/lib/api-client/http-client-mock.js
@@ -16,6 +16,11 @@ var Events = require('./../events'),
 var HttpClientMock = function(config) {
   config = config || {};
 
+  config.headers = config.headers || {};
+  if (!config.headers.Accept) {
+    config.headers.Accept = 'application/hal+json, application/json; q=0.5';
+  }
+
   if (!config.baseUrl) {
     throw new Error('HttpClientMock needs a `baseUrl` configuration property.');
   }

--- a/lib/api-client/http-client.js
+++ b/lib/api-client/http-client.js
@@ -112,13 +112,12 @@ HttpClient.prototype.load = function(url, options) {
   var done = options.done || noop;
   var self = this;
 
-  if (options.accept) {
-    this.config.headers.Accept = options.accept;
-  }
+  var accept = options.accept || this.config.headers.Accept;
 
   var req = request
     .get(url)
     .set(this.config.headers)
+    .set('Accept', accept)
     .query(options.data || {});
 
   req.end(end(self, done));

--- a/lib/api-client/http-client.js
+++ b/lib/api-client/http-client.js
@@ -16,6 +16,11 @@ var noop = function() {};
 var HttpClient = function(config) {
   config = config || {};
 
+  config.headers = config.headers || {};
+  if (!config.headers.Accept) {
+    config.headers.Accept = 'application/hal+json, application/json; q=0.5';
+  }
+
   if (!config.baseUrl) {
     throw new Error('HttpClient needs a `baseUrl` configuration property.');
   }
@@ -83,7 +88,7 @@ HttpClient.prototype.post = function(path, options) {
   }
 
   req
-    .set('Accept', 'application/hal+json, application/json; q=0.5')
+    .set(this.config.headers)
     .send(options.data || {})
     .query(options.query || {});
 
@@ -107,11 +112,13 @@ HttpClient.prototype.load = function(url, options) {
   var done = options.done || noop;
   var self = this;
 
-  var accept = options.accept || 'application/hal+json, application/json; q=0.5';
+  if (options.accept) {
+    this.config.headers.Accept = options.accept;
+  }
 
   var req = request
     .get(url)
-    .set('Accept', accept)
+    .set(this.config.headers)
     .query(options.data || {});
 
   req.end(end(self, done));
@@ -129,7 +136,7 @@ HttpClient.prototype.put = function(path, options) {
 
   var req = request
     .put(url)
-    .set('Accept', 'application/hal+json, application/json; q=0.5')
+    .set(this.config.headers)
     .send(options.data || {});
 
   req.end(end(self, done));
@@ -148,7 +155,7 @@ HttpClient.prototype.del = function(path, options) {
 
   var req = request
     .del(url)
-    .set('Accept', 'application/hal+json, application/json; q=0.5')
+    .set(this.config.headers)
     .send(options.data || {});
 
   req.end(end(self, done));
@@ -166,7 +173,7 @@ HttpClient.prototype.options = function(path, options) {
   var url = this.config.baseUrl + (path ? '/'+ path : '');
 
   var req = request('OPTIONS', url)
-    .set('Accept', 'application/hal+json, application/json; q=0.5');
+    .set(this.config.headers);
 
   req.end(end(self, done));
 };

--- a/lib/api-client/index.js
+++ b/lib/api-client/index.js
@@ -20,6 +20,7 @@ var Events = require('./../events');
  * @param  {Object} config                  used to provide necessary configuration
  * @param  {String} [config.engine=default]
  * @param  {String} config.apiUri
+ * @param  {String} [config.headers]        Headers that should be used for all Http requests.
  */
 function CamundaClient(config) {
   if (!config) {
@@ -104,7 +105,7 @@ CamundaClient.HttpClient = require('./http-client');
     }
 
     // create global HttpClient instance
-    this.http = new this.HttpClient({baseUrl: this.baseUrl});
+    this.http = new this.HttpClient({baseUrl: this.baseUrl, headers: this.config.headers});
 
     // configure the client for each resources separately,
     var name, conf, resConf, c;

--- a/lib/api-client/index.js
+++ b/lib/api-client/index.js
@@ -116,9 +116,7 @@ CamundaClient.HttpClient = require('./http-client');
         // use the SDK config for some default values
         mock:     this.config.mock,
         baseUrl:  this.baseUrl,
-        headers:  {
-          // we might want to set headers or
-        }
+        headers:  this.config.headers
       };
       resConf = this.config.resources[name] || {};
 


### PR DESCRIPTION
I need custom headers to allow authentication through a gateway. I saw there was already an open ticket for this feature: [CAM-4069](https://app.camunda.com/jira/browse/CAM-4069)

Example usage:

```JavaScript
var sdkClient = new CamSDK.Client({
    apiUri: 'http://example.com:8080/engine-rest',
    mock: false,
    headers: {'X-Requested-With': 'AngularJs'}
});
```