### PR TITLE
Allow to configure absolute API URI

### DIFF
--- a/lib/api-client/index.js
+++ b/lib/api-client/index.js
@@ -18,7 +18,7 @@ var Events = require('./../events');
  * @memberof CamSDK.client
  *
  * @param  {Object} config                  used to provide necessary configuration
- * @param  {String} [config.engine=default]
+ * @param  {String} [config.engine=default] false to define absolute apiUri
  * @param  {String} config.apiUri
  * @param  {String} [config.headers]        Headers that should be used for all Http requests.
  */
@@ -33,7 +33,10 @@ function CamundaClient(config) {
 
   Events.attach(this);
 
-  config.engine = config.engine || 'default';
+  // use 'default' engine
+  config.engine = typeof config.engine !== 'undefined'
+    ? config.engine
+    : 'default';
 
   // mock by default.. for now
   config.mock =  typeof config.mock !== 'undefined' ? config.mock : true;
@@ -43,10 +46,10 @@ function CamundaClient(config) {
   this.HttpClient = config.HttpClient || CamundaClient.HttpClient;
 
   this.baseUrl = config.apiUri;
-  if(this.baseUrl.slice(-1) !== '/') {
-    this.baseUrl += '/';
+  if (config.engine) {
+    this.baseUrl += (this.baseUrl.slice(-1) !== '/' ? '/' : '');
+    this.baseUrl += 'engine/'+ config.engine;
   }
-  this.baseUrl += 'engine/'+ config.engine;
 
   this.config = config;
 

--- a/test/client/coreSpec.js
+++ b/test/client/coreSpec.js
@@ -55,6 +55,11 @@ describe('The SDK core', function() {
     });
   });
 
+  it('has a baseUrl', function() {
+    var baseUrl = ProcessDefinition.http.config.baseUrl;
+    expect(baseUrl).to.eql('engine-rest/engine/engine/default');
+  });
+
   it('returns promises', function() {
     expect(function() {
       ProcessDefinition = camClient.resource('process-definition');
@@ -155,6 +160,59 @@ describe('The SDK core', function() {
             done();
           }
         });
+    });
+  });
+});
+
+describe('The custom configured SDK core', function() {
+
+  var baseUrl = 'engine-rest/engine';
+  var mockConfig = require('../superagent-mock-config');
+  var superagentMock;
+
+  before(function() {
+    mockConfig[0].pattern = baseUrl + '/(.*)';
+    superagentMock = require('superagent-mock')(request, mockConfig);
+  });
+
+  after(function() {
+    superagentMock.unset();
+  });
+
+  var CamSDK, camClient, ProcessDefinition;
+
+  it('does not blow when loading', function() {
+    expect(function() {
+      CamSDK = require('./../../lib/index');
+    }).not.to.throw();
+  });
+
+
+  it('initializes', function() {
+    expect(function() {
+      camClient = new CamSDK.Client({
+        engine: false,
+        apiUri: baseUrl
+      });
+    }).not.to.throw();
+  });
+
+  it('has an unmodified baseUrl', function() {
+    ProcessDefinition = camClient.resource('process-definition');
+    expect(ProcessDefinition.http.config.baseUrl).to.eql(baseUrl);
+  });
+
+  it('uses the absolut apiUri', function(done) {
+    ProcessDefinition.list({
+      nameLike: 'Bar'
+    }, function(err, results) {
+      expect(err).to.be.null;
+
+      expect(results.count).to.not.be.undefined;
+
+      expect(Array.isArray(results.items)).to.eql(true);
+
+      done();
     });
   });
 });


### PR DESCRIPTION
I wanted to use the client with an embedded API that does not expose the engine via the default `/engine/{name}` mapping. Hope I didn't overlook a simple setting that I could have used, but I added a feature that makes the client interpret the `apiUri` config as an absolute URI to the API endpoints. 

The users need to set the config options `engine` to `false`explicitly, so it should be backwards compatible.