### PR TITLE
Make AngularJS peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "underscore.string": "2.3.3",
     "uuid": "1.4.1"
   },
-  "optionalDependencies": {
-    "angular": "1.2.29"
+  "peerDependency": {
+    "angular": "^1.2.29"
   }
 }

--- a/vendor/angular.js
+++ b/vendor/angular.js
@@ -1,3 +1,0 @@
-'use strict';
-
-module.exports = require('angular');


### PR DESCRIPTION
This aims to resolve #23.

With npm version 3 and above peerDependencies are not installed, so these deps need to be specified in the host app/package explicitly. By making AngularJS a peerDependency we can make sure the actual `angular` as specified in the client application that depends on the SDK is `required` and not shadowed by a local installation within the package folder. 

If the package is used without specifying an Angular version yarn/npm will emit a warning after installation. Applications that do not use the angular integration can safely ignore this warning.

To run AngularJS related tests, the peerDependency needs to be installed with the package manually. As the semver has been upped to ^1.2.29 it will default to 1.5.9 as of this writing (I don't see any harm in this as I have been using the SDK this way a while now). To test with the fixed version (probably used by the Camunda web front?) a version tag can be added:

````
$ npm install angular@1.2.29
$ grunt karma:dev-form-angularjs
...
Chrome 54.0.2840 (Mac OS X 10.12.1): Executed 6 of 6 SUCCESS (0.186 secs / 0.149 secs)
````

This also removes the vendor dir that included a `angular` mock that has not been in use (at least from my understanding?).