### PR TITLE
Fix querying for process instances.

### DIFF
--- a/lib/api-client/resources/process-instance.js
+++ b/lib/api-client/resources/process-instance.js
@@ -48,6 +48,13 @@ var ProcessInstance = AbstractClientResource.extend(
       return this.http.post(params, done);
     },
 
+    /**
+     * Queries for process instances that fulfill given parameters.
+     * @see https://docs.camunda.org/manual/latest/reference/rest/process-instance/get-query/
+     *
+     * @param  {Object}          params
+     * @param  {requestCallback} done
+     */
     list: function(params, done) {
       var path = this.path;
 
@@ -55,7 +62,7 @@ var ProcessInstance = AbstractClientResource.extend(
       path += '?firstResult='+ (params.firstResult || 0);
       path += '&maxResults='+ (params.maxResults || 15);
 
-      return this.http.post(path, {
+      return this.http.get(path, {
         data: params,
         done: done
       });


### PR DESCRIPTION
Switched from a `post` to a `get` to line up with the documentation.

This was causing an issue when you attempt to query for process instances with given `variables` - the server could not deserialize the parameters into Objects.

An example of a previously failing call looks like:
```
processInstanceResouce.list({ variables: 'myCustomVar_eq_foo' });
```